### PR TITLE
[Bugfix] prevent infinite looping conversation while seenTutorial is undefined

### DIFF
--- a/handlers/index.js
+++ b/handlers/index.js
@@ -119,6 +119,7 @@ const handlers = [
   {
     state: [{ seenTutorial: false }, { seenTutorial: undefined }],
     handler: async (context, db, terminate) => {
+      context.setState({ seenTutorial: false });
       await context.sendText(
         "嗨嗨你好，我是功德無量打卡機本人，請叫我阿德就好。",
         genQuickReply([{ text: "你是誰? 你可以幹嘛?" }])


### PR DESCRIPTION
bug:
當使用者在 seenTutorial 這個 state 尚未出現前就使用過機器人。
再次使用時，會因為是 undefined 造成對話鬼打牆。

