### PR TITLE
[Bugfix] 修正Cronjob的Promise chaining

### DIFF
--- a/cronjob/index.js
+++ b/cronjob/index.js
@@ -73,7 +73,8 @@ async function main() {
     if (promiseQueue.length < REMINDER_MAX_SENDING_NUM) {
       promiseQueue.push(sendRemindText(client, reminder));
     } else {
-      promiseQueue[index % REMINDER_MAX_SENDING_NUM].then(() =>
+      const modIndex = index % REMINDER_MAX_SENDING_NUM;
+      promiseQueue[modIndex] = promiseQueue[modIndex].then(() =>
         sendRemindText(client, reminder)
       );
     }


### PR DESCRIPTION
超出queue長度的Promise接在先前的promise的後面之後，要取代原本的proimse